### PR TITLE
Change how packages are installed

### DIFF
--- a/roles/installPackages/defaults/main.yaml
+++ b/roles/installPackages/defaults/main.yaml
@@ -11,3 +11,9 @@ packages_yum_present: []
 
 packages_dnf_latest: []
 packages_dnf_present: []
+
+# NEW!
+packages_legacy: no
+packages_latest: []
+packages_present: []
+packages_absent: []

--- a/roles/installPackages/tasks/main.yaml
+++ b/roles/installPackages/tasks/main.yaml
@@ -11,16 +11,19 @@
     name: "{{ item }}"
     state: latest
   with_items: "{{ packages_latest }}"
+  when: not packages_legacy
 
 - name: ensure the specified packages are present, even if not the latest version
     ansible.builtin.package:
     name: "{{ item }}"
     state: present
   with_items: "{{ packages_present }}"
+  when: not packages_legacy
 
 - name: remove the specified packages altogether
   ansible.builtin.package:
     name: "{{ item }}"
     state: absent
   with_items: "{{ packages_absent }}"
+  when: not packages_legacy
 #EOF

--- a/roles/installPackages/tasks/main.yaml
+++ b/roles/installPackages/tasks/main.yaml
@@ -4,4 +4,23 @@
     params:
       files:
         - "pkg-{{ ansible_pkg_mgr }}.yaml"
+  when: packages_legacy
+
+- name: install the latest versions of specified packages
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ packages_latest }}"
+
+- name: ensure the specified packages are present, even if not the latest version
+    ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ packages_present }}"
+
+- name: remove the specified packages altogether
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: absent
+  with_items: "{{ packages_absent }}"
 #EOF


### PR DESCRIPTION
Instead of specifying what apt/dnf/yum packages to install, simply make use of host variables.

Old way retained with "`packages_legacy`" (default: false) variable for those that don't update often.